### PR TITLE
remove unused Token

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 (function(){
 
-var string = require('string'),
-    Token = require('markdown-it/lib/token');
+var string = require('string');
 
 var default_slugify = function(s) {
   return string(s).slugify().toString();


### PR DESCRIPTION
`Token` is not in use, `markdown-it` is not required in package.json either. This will throw a error on import.